### PR TITLE
It is better to use the repository field

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.1"
 edition = "2021"
 
 description = "The core of sapphire-hash."
-homepage = "https://github.com/rhian-cs/sapphire-hash"
+repository = "https://github.com/rhian-cs/sapphire-hash"
 license = "MIT"
 
 [dependencies]


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.